### PR TITLE
Remove test project runtimes

### DIFF
--- a/test/Tinify.Tests.Integration/project.json
+++ b/test/Tinify.Tests.Integration/project.json
@@ -1,9 +1,6 @@
 ﻿{
   "supports": {},
-  "runtimes": {
-    "win7-x64": {},
-    "osx.10.12-x64": {}
-  },
+
   "testRunner": "nunit",
   "dependencies": {
     "NETStandard.Library": "1.6.1",
@@ -12,7 +9,18 @@
     "Tinify": "*"
   },
   "frameworks": {
-    "netcoreapp1.1": {}
+    "netcoreapp1.1": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.1.0"
+        }
+      },
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
   },
   "buildOptions": {
     "copyToOutput": "examples/voormedia.png"

--- a/test/Tinify.Tests/project.json
+++ b/test/Tinify.Tests/project.json
@@ -1,9 +1,6 @@
 {
   "supports": {},
-  "runtimes": {
-    "win7-x64": {},
-    "osx.10.12-x64": {}
-  },
+ 
   "testRunner": "nunit",
   "dependencies": {
     "RichardSzalay.MockHttp": "1.3.0",
@@ -13,6 +10,18 @@
     "Tinify": "*"
   },
   "frameworks": {
-    "netcoreapp1.1": {}
+    "netcoreapp1.1": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.1.0"
+        }
+      },
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+
   }
 }


### PR DESCRIPTION
This removes the need to specify the runtime section and thus being able to build and test on multiple platforms