### PR TITLE
Make Client Disposable

### DIFF
--- a/src/Tinify/Client.cs
+++ b/src/Tinify/Client.cs
@@ -13,7 +13,7 @@ namespace TinifyAPI
 {
     using Method = HttpMethod;
 
-    public class Client
+    public class Client : IDisposable
     {
         public static readonly Uri ApiEndpoint = new Uri("https://api.tinify.com");
 
@@ -161,6 +161,24 @@ namespace TinifyAPI
             }
 
             return null;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (client != null)
+                {
+                    client.Dispose();
+                    client = null;
+                }
+            }
         }
     }
 }

--- a/src/Tinify/Tinify.cs
+++ b/src/Tinify/Tinify.cs
@@ -27,7 +27,7 @@ namespace TinifyAPI
             set
             {
                 key = value;
-                client = null;
+                ResetClient();
             }
         }
 
@@ -41,7 +41,7 @@ namespace TinifyAPI
             set
             {
                 appIdentifier = value;
-                client = null;
+                ResetClient();
             }
         }
 
@@ -55,8 +55,17 @@ namespace TinifyAPI
             set
             {
                 proxy = value;
-                client = null;
+                ResetClient();
             }
+        }
+
+        private static void ResetClient()
+        {
+            if (client != null)
+            {
+                client.Dispose();
+            }
+            client = null;
         }
 
         public static uint CompressionCount { get; set; }


### PR DESCRIPTION
Since Client uses an instance of HttpClient and at it's core it is a Diposable object, the rule of thumb is at least we should propagate that Disposable behavior so that when our client gets disposed we also dispose explicitly the HttpClient

There is some wording that we should not dispose HttpClient, but that is a miss assumption. We should not dispose the HttpClient on a per request basis and we don't actually do that (at least using the Tinify entry point).