### PR TITLE
Add Tinify.ValidateServerCertificate API to optionally validate the server certificate (fixes #6). Rename 'Exception' to 'TinifyException' (fixes #12).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,6 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# MFractors (Xamarin productivity tool) working folder
+.mfractor/

--- a/src/Tinify/Client.cs
+++ b/src/Tinify/Client.cs
@@ -22,12 +22,14 @@ namespace TinifyAPI
 
         HttpClient client;
 
-        public Client(string key, string appIdentifier = null, string proxy = null)
+        public Client(string key, string appIdentifier = null, string proxy = null, bool validateServerCertificate = true)
         {
-            var handler = new HttpClientHandler()
+            var handler = new HttpClientHandler();
+
+            if (validateServerCertificate)
             {
-                ServerCertificateCustomValidationCallback = Internal.SSL.ValidationCallback
-            };
+                handler.ServerCertificateCustomValidationCallback = Internal.SSL.ValidationCallback;
+            }
 
             if (proxy != null)
             {
@@ -155,7 +157,7 @@ namespace TinifyAPI
                 }
 
                 if (retries > 0 && (uint) response.StatusCode >= 500) continue;
-                throw Exception.Create(data.message, data.error, (uint) response.StatusCode);
+                throw TinifyException.Create(data.message, data.error, (uint) response.StatusCode);
             }
 
             return null;

--- a/src/Tinify/Tinify.cs
+++ b/src/Tinify/Tinify.cs
@@ -15,6 +15,7 @@ namespace TinifyAPI
         private static string key;
         private static string appIdentifier;
         private static string proxy;
+        private static bool validateServerCertificate = true;
 
         public static string Key
         {
@@ -58,6 +59,20 @@ namespace TinifyAPI
             }
         }
 
+        public static bool ValidateServerCertificate
+        {
+            get
+            {
+                return validateServerCertificate;
+            }
+
+            set
+            {
+                validateServerCertificate = value;
+                ResetClient();
+            }
+        }
+
         private static void ResetClient()
         {
             if (client != null)
@@ -88,7 +103,7 @@ namespace TinifyAPI
                     {
                         if (client == null)
                         {
-                            client = new Client(key, appIdentifier, proxy);
+                            client = new Client(key, appIdentifier, proxy, validateServerCertificate);
                         }
                     }
                     return client;

--- a/src/Tinify/TinifyException.cs
+++ b/src/Tinify/TinifyException.cs
@@ -1,7 +1,7 @@
 namespace TinifyAPI
 {
-    public class Exception : System.Exception {
-        internal static Exception Create(string message, string type, uint status) {
+    public class TinifyException : System.Exception {
+        internal static TinifyException Create(string message, string type, uint status) {
             if (status == 401 || status == 429)
             {
                 return new AccountException(message, type, status);
@@ -16,24 +16,24 @@ namespace TinifyAPI
             }
             else
             {
-                return new Exception(message, type, status);
+                return new TinifyException(message, type, status);
             }
         }
 
         public uint Status = 0;
 
-        internal Exception() : base() {}
+        internal TinifyException() : base() {}
 
-        internal Exception(string message, System.Exception err = null) : base(message, err) { }
+        internal TinifyException(string message, System.Exception err = null) : base(message, err) { }
 
-        internal Exception(string message, string type, uint status) :
+        internal TinifyException(string message, string type, uint status) :
             base(message + " (HTTP " + status + "/" + type + ")")
         {
             this.Status = status;
         }
     }
 
-    public class AccountException : Exception
+    public class AccountException : TinifyException
     {
         internal AccountException() : base() {}
 
@@ -42,7 +42,7 @@ namespace TinifyAPI
         internal AccountException(string message, string type, uint status) : base(message, type, status) { }
     }
 
-    public class ClientException : Exception
+    public class ClientException : TinifyException
     {
         internal ClientException() : base() {}
 
@@ -51,7 +51,7 @@ namespace TinifyAPI
         internal ClientException(string message, string type, uint status) : base(message, type, status) { }
     }
 
-    public class ServerException : Exception
+    public class ServerException : TinifyException
     {
         internal ServerException() : base() {}
 
@@ -60,7 +60,7 @@ namespace TinifyAPI
         internal ServerException(string message, string type, uint status) : base(message, type, status) { }
     }
 
-    public class ConnectionException : Exception
+    public class ConnectionException : TinifyException
     {
         internal ConnectionException() : base() {}
 


### PR DESCRIPTION
 * Add `Tinify.ValidateServerCertificate` API to optionally validate the server certificate. By default, this is `true`. This is a workaround for using Tinify on non-windows platforms where `HttpClient.ServerCertificateCustomValidationCallback` is not implemented. See #6.
 * Rename `Exception` to `TinifyException` as Exception conflicts with System.Exception. By using TinifyException, consumers can use the library without fully qualifying usages of `System.Exception` in their source code; this improves user experience and tightens the API design. See #12.
 * Add exclusion rules for MFractor to .gitignore.