### PR TITLE
Upgraded Json.Net package and moved Tinify testing library to .Net 6.0. Fixed breaking tests.

### DIFF
--- a/src/Tinify/Client.cs
+++ b/src/Tinify/Client.cs
@@ -16,7 +16,7 @@ namespace TinifyAPI
         public static readonly Uri ApiEndpoint = new Uri("https://api.tinify.com");
 
         public static readonly ushort RetryCount = 1;
-        public static readonly ushort RetryDelay = 500;
+        public static ushort RetryDelay { get; internal set; }= 500;
 
         public static readonly string UserAgent = Internal.Platform.UserAgent;
 

--- a/src/Tinify/Tinify.csproj
+++ b/src/Tinify/Tinify.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Tinify</AssemblyTitle>
     <VersionPrefix>1.5.3</VersionPrefix>
     <Authors>Tinify</Authors>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard1.4</TargetFramework>
     <AssemblyName>Tinify</AssemblyName>
     <PackageId>Tinify</PackageId>
     <PackageTags>tinify;tinypng;tinyjpg;compress;images;api</PackageTags>

--- a/src/Tinify/Tinify.csproj
+++ b/src/Tinify/Tinify.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Tinify</AssemblyTitle>
     <VersionPrefix>1.5.3</VersionPrefix>
     <Authors>Tinify</Authors>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Tinify</AssemblyName>
     <PackageId>Tinify</PackageId>
     <PackageTags>tinify;tinypng;tinyjpg;compress;images;api</PackageTags>
@@ -14,7 +14,6 @@
     <PackageLicenseUrl>https://github.com/tinify/tinify-net/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/tinify/tinify-net.git</RepositoryUrl>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -33,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/test/Tinify.Tests.Integration/Tinify.Tests.Integration.csproj
+++ b/test/Tinify.Tests.Integration/Tinify.Tests.Integration.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Tinify.Tests.Integration</AssemblyName>
     <PackageId>Tinify.Tests.Integration</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
-    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/Tinify.Tests.Integration/Tinify.Tests.Integration.csproj
+++ b/test/Tinify.Tests.Integration/Tinify.Tests.Integration.csproj
@@ -23,12 +23,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetEnv" Version="1.4.0" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="3.2.1" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.7.0" />
+    <PackageReference Include="DotNetEnv" Version="2.3.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.2" />
   </ItemGroup>
 
   <Target Name="CopyEnv" AfterTargets="AfterBuild">

--- a/test/Tinify.Tests/ClientTest.cs
+++ b/test/Tinify.Tests/ClientTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using RichardSzalay.MockHttp;
 
@@ -66,7 +67,7 @@ namespace TinifyAPI.Tests
         public void Should_IssueRequest_WithoutBody_WhenOptionsAreEmpty()
         {
             var response = Subject.Request(HttpMethod.Post, "/shrink").Result;
-            Assert.AreEqual(null, response.Content);
+            Assert.IsInstanceOf(Helper.EmptyContentType, response.Content);
         }
 
         [Test]
@@ -190,7 +191,7 @@ namespace TinifyAPI.Tests
         public void Should_ReturnResponse()
         {
             var response = Subject.Request(HttpMethod.Post, "/shrink").Result;
-            Assert.AreEqual(null, response.Content);
+            Assert.IsInstanceOf(Helper.EmptyContentType, response.Content);
         }
     }
 
@@ -256,7 +257,7 @@ namespace TinifyAPI.Tests
         public void Should_ReturnResponse()
         {
             var response = Subject.Request(HttpMethod.Post, "/shrink").Result;
-            Assert.AreEqual(null, response.Content);
+            Assert.IsInstanceOf(Helper.EmptyContentType, response.Content);
         }
     }
 
@@ -322,7 +323,7 @@ namespace TinifyAPI.Tests
         public void Should_ReturnResponse()
         {
             var response = Subject.Request(HttpMethod.Post, "/shrink").Result;
-            Assert.AreEqual(null, response.Content);
+            Assert.IsInstanceOf(Helper.EmptyContentType, response.Content);
         }
     }
 
@@ -388,7 +389,7 @@ namespace TinifyAPI.Tests
         public void Should_ReturnResponse()
         {
             var response = Subject.Request(HttpMethod.Post, "/shrink").Result;
-            Assert.AreEqual(null, response.Content);
+            Assert.IsInstanceOf(Helper.EmptyContentType, response.Content);
         }
     }
 
@@ -454,7 +455,7 @@ namespace TinifyAPI.Tests
         public void Should_ReturnResponse()
         {
             var response = Subject.Request(HttpMethod.Post, "/shrink").Result;
-            Assert.AreEqual(null, response.Content);
+            Assert.IsInstanceOf(Helper.EmptyContentType, response.Content);
         }
     }
 

--- a/test/Tinify.Tests/ClientTest.cs
+++ b/test/Tinify.Tests/ClientTest.cs
@@ -1,12 +1,10 @@
 ﻿using NUnit.Framework;
-
+using RichardSzalay.MockHttp;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
-using RichardSzalay.MockHttp;
 
 namespace TinifyAPI.Tests
 {

--- a/test/Tinify.Tests/Helper.cs
+++ b/test/Tinify.Tests/Helper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
@@ -13,8 +14,7 @@ namespace TinifyAPI.Tests
         static FieldInfo httpHandlerField = typeof(HttpMessageInvoker)
             .GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic);
 
-        static FieldInfo retryDelayField = typeof(Client)
-            .GetField("RetryDelay", BindingFlags.Static | BindingFlags.Public);
+        public static Type EmptyContentType = typeof(HttpResponseMessage).Assembly.GetType("System.Net.Http.EmptyContent");
 
         public static MockHttpMessageHandler MockHandler;
         public static HttpRequestMessage LastRequest;
@@ -28,7 +28,7 @@ namespace TinifyAPI.Tests
             var client = (HttpClient) httpClientField.GetValue(test);
             httpHandlerField.SetValue(client, MockHandler);
 
-            retryDelayField.SetValue(null, (ushort) 10);
+            Client.RetryDelay = 10;
         }
 
         public static void EnqueuShrink(Client test)

--- a/test/Tinify.Tests/Helper.cs
+++ b/test/Tinify.Tests/Helper.cs
@@ -14,7 +14,7 @@ namespace TinifyAPI.Tests
         static FieldInfo httpHandlerField = typeof(HttpMessageInvoker)
             .GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic);
 
-        public static Type EmptyContentType = typeof(HttpResponseMessage).Assembly.GetType("System.Net.Http.EmptyContent");
+        public static Type EmptyContentType = typeof(HttpContent).Assembly.GetType("System.Net.Http.EmptyContent");
 
         public static MockHttpMessageHandler MockHandler;
         public static HttpRequestMessage LastRequest;

--- a/test/Tinify.Tests/Tinify.Tests.csproj
+++ b/test/Tinify.Tests/Tinify.Tests.csproj
@@ -12,11 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RichardSzalay.MockHttp" Version="3.2.1" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.7.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Tinify.Tests/Tinify.Tests.csproj
+++ b/test/Tinify.Tests/Tinify.Tests.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Tinify.Tests</AssemblyName>
     <PackageId>Tinify.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
-    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In the process of trying to deal with the security issue related to the older Json.Net library, I figured I would also bump the testing assembly framework to 6.0 since they can still consume a .Net standard 1.4 library. I needed to do this as I could not get the testing assemblies to build or run correctly on my system without installing older frameworks, which I have no need of. I also went ahead and updated the NuGet packages for all of the testing assemblies and verified that all tests, including the integration tests, are passing. It did require some minor code changes in the testing assemblies due to some breaking changes in the System.Net.Http assembly, as well as a reflection behavior change that caused the tests to fail due to not being able to set an init only value. I updated the Client.cs file to deal with this issue by making it a public get and internal set property. This loses the potential performance gain of a readonly value, but makes it testable.
